### PR TITLE
Do not panic in Drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.4.3"
 fastrand = "2.3.0"
 las-crs = "0.1.1"
 las = { version = "0.9.2", features = ["laz"] }
-laz = "0.9.2"
+laz = "0.12"
 log = "0.4.25"
 thiserror = "2.0.6"
 crs-definitions = "0.3.0"

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -828,10 +828,12 @@ fn get_random_weighted_index(entries: &Vec<&mut Entry>) -> usize {
 impl<W: Write + Seek> Drop for CopcWriter<'_, W> {
     fn drop(&mut self) {
         if !self.is_closed {
-            // can only happen if the writer is created but no points is written
-            // or something goes wrong while writing
-            self.close()
-                .expect("Error when dropping the writer. No points written.");
+            // A Drop impl must never panic. This runs when a writer is created but
+            // never written, or when a write errored before close() set is_closed --
+            // and a panic here while another panic is unwinding aborts the process.
+            // Best-effort close; callers who need to observe close errors should keep
+            // the writer and finish the write explicitly rather than rely on Drop.
+            let _ = self.close();
         }
     }
 }

--- a/tests/drop_does_not_panic.rs
+++ b/tests/drop_does_not_panic.rs
@@ -1,0 +1,42 @@
+//! Regression test: dropping a `CopcWriter` must never panic.
+//!
+//! Before the fix, `Drop` called `self.close().expect(...)`, so a writer that was
+//! constructed but never written (or whose write errored before close) panicked on
+//! drop -- and a panic in Drop during unwinding aborts the process.
+
+use std::io::Cursor;
+
+use copc_rs::CopcWriter;
+use las::point::Format;
+use las::{Builder, Transform, Vector, Vlr};
+
+const WKT: &[u8] = b"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+
+fn header() -> las::Header {
+    let mut b = Builder::from((1u8, 4u8));
+    b.point_format = Format::new(6).unwrap();
+    let t = Transform { scale: 0.01, offset: 0.0 };
+    b.transforms = Vector { x: t, y: t, z: t };
+    let mut raw = b.into_header().unwrap().into_raw().unwrap();
+    raw.min_x = 0.0;
+    raw.max_x = 100.0;
+    raw.min_y = 0.0;
+    raw.max_y = 100.0;
+    raw.min_z = 0.0;
+    raw.max_z = 100.0;
+    let mut b2 = Builder::new(raw).unwrap();
+    b2.vlrs.push(Vlr {
+        user_id: "LASF_Projection".into(),
+        record_id: 2112,
+        description: String::new(),
+        data: WKT.to_vec(),
+    });
+    b2.into_header().unwrap()
+}
+
+#[test]
+fn dropping_an_unwritten_writer_does_not_panic() {
+    let w = CopcWriter::new(Cursor::new(Vec::<u8>::new()), header(), -1, -1).unwrap();
+    assert!(!w.is_closed());
+    drop(w); // pre-fix: panics with EmptyCopcFile; post-fix: clean.
+}

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,64 @@
+//! Regression test for the build against current `las`/`laz`, plus a basic
+//! write -> read round-trip through copc-rs's own writer and reader.
+//!
+//! With copc-rs's stale `laz = "0.9"` pin, a fresh dependency resolution selects
+//! `las 0.9.11` (which uses `laz 0.12`) while copc-rs pulls `laz 0.9`, so
+//! `header.laz_vlr()` is a different `LazVlr` type and the crate does not compile.
+//! This test therefore fails to *build* before the fix and passes after it.
+
+use std::io::Cursor;
+
+use copc_rs::{BoundsSelection, CopcReader, CopcWriter, LodSelection};
+use las::point::Format;
+use las::{Builder, Point, Transform, Vector, Vlr};
+
+const WKT: &[u8] = b"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+
+fn header_with_bounds() -> las::Header {
+    let mut b = Builder::from((1u8, 4u8));
+    b.point_format = Format::new(6).unwrap();
+    let t = Transform { scale: 0.01, offset: 0.0 };
+    b.transforms = Vector { x: t, y: t, z: t };
+    // raw round-trip only to stamp non-degenerate bounds (Builder has no bounds field)
+    let mut raw = b.into_header().unwrap().into_raw().unwrap();
+    raw.min_x = 0.0;
+    raw.max_x = 100.0;
+    raw.min_y = 0.0;
+    raw.max_y = 100.0;
+    raw.min_z = 0.0;
+    raw.max_z = 100.0;
+    // VLRs are not part of raw::Header, so add the mandatory WKT CRS VLR afterwards.
+    let mut b2 = Builder::new(raw).unwrap();
+    b2.vlrs.push(Vlr {
+        user_id: "LASF_Projection".into(),
+        record_id: 2112,
+        description: String::new(),
+        data: WKT.to_vec(),
+    });
+    b2.into_header().unwrap()
+}
+
+#[test]
+fn writes_and_reads_back_all_points() {
+    let pts: Vec<Point> = (0..500)
+        .map(|i| {
+            let f = (i % 100) as f64;
+            Point { x: f, y: f, z: f, gps_time: Some(1000.0 + i as f64), ..Default::default() }
+        })
+        .collect();
+    let n = pts.len();
+
+    let mut buf = Cursor::new(Vec::<u8>::new());
+    {
+        let mut w = CopcWriter::new(&mut buf, header_with_bounds(), -1, -1).unwrap();
+        w.write(pts, n as i32).unwrap();
+    }
+
+    buf.set_position(0);
+    let mut r = CopcReader::new(buf).unwrap();
+    let read = r
+        .points(LodSelection::All, BoundsSelection::All)
+        .unwrap()
+        .count();
+    assert_eq!(read, n, "every written point must round-trip");
+}


### PR DESCRIPTION
`CopcWriter::drop` calls `self.close().expect(...)`. `is_closed` is only set on a **successful** `close()`, so two reachable paths panic on drop:

- a writer constructed but never written — `close()` returns `Err(EmptyCopcFile)`;
- a write that errored before `close()` completed.

A panic in `Drop` while another panic is unwinding aborts the process, so this is a latent crash. This makes `Drop` a best-effort close that ignores the error; callers that need to observe close errors should finish the write explicitly rather than rely on `Drop`. Adds `tests/drop_does_not_panic.rs` (panics before the fix, clean after).

---
Stacked on #12 — the crate doesn't build against current `las` without that fix, so this branch includes its one commit. Happy to rebase to a single commit once #12 merges.
