### PR TITLE
Preserve an existing EVLR in the written header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.4.3"
 fastrand = "2.3.0"
 las-crs = "0.1.1"
 las = { version = "0.9.2", features = ["laz"] }
-laz = "0.9.2"
+laz = "0.12"
 log = "0.4.25"
 thiserror = "2.0.6"
 crs-definitions = "0.3.0"

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -577,7 +577,7 @@ impl<W: Write + Seek> CopcWriter<'_, W> {
             .get_mut()
             .seek(SeekFrom::Start(self.start))?;
         self.header.clone().into_raw().and_then(|mut raw_header| {
-            if let Some(mut e) = raw_header.evlr {
+            if let Some(e) = &mut raw_header.evlr {
                 e.start_of_first_evlr = start_of_first_evlr;
                 e.number_of_evlrs += 1;
             } else {

--- a/tests/evlr_roundtrip.rs
+++ b/tests/evlr_roundtrip.rs
@@ -1,0 +1,68 @@
+//! Regression test: an EVLR already present in the input header must not corrupt
+//! the written COPC's EVLR offset/count, which the reader uses to locate the EPT
+//! hierarchy. Before the fix, the header's `start_of_first_evlr`/`number_of_evlrs`
+//! were updated on a discarded local copy (the input's stale values were written),
+//! so the reader could not find the COPC hierarchy EVLR.
+
+use std::io::Cursor;
+
+use copc_rs::{BoundsSelection, CopcReader, CopcWriter, LodSelection};
+use las::point::Format;
+use las::{Builder, Point, Transform, Vector, Vlr};
+
+const WKT: &[u8] = b"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+
+fn header_with_extra_evlr() -> las::Header {
+    let mut b = Builder::from((1u8, 4u8));
+    b.point_format = Format::new(6).unwrap();
+    let t = Transform { scale: 0.01, offset: 0.0 };
+    b.transforms = Vector { x: t, y: t, z: t };
+    let mut raw = b.into_header().unwrap().into_raw().unwrap();
+    raw.min_x = 0.0;
+    raw.max_x = 100.0;
+    raw.min_y = 0.0;
+    raw.max_y = 100.0;
+    raw.min_z = 0.0;
+    raw.max_z = 100.0;
+    let mut b2 = Builder::new(raw).unwrap();
+    b2.vlrs.push(Vlr {
+        user_id: "LASF_Projection".into(),
+        record_id: 2112,
+        description: String::new(),
+        data: WKT.to_vec(),
+    });
+    // A pre-existing EVLR in the input header -- the path that triggered the bug.
+    b2.evlrs.push(Vlr {
+        user_id: "TESTVEND".into(),
+        record_id: 4242,
+        description: String::new(),
+        data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+    });
+    b2.into_header().unwrap()
+}
+
+#[test]
+fn pre_existing_input_evlr_keeps_hierarchy_readable() {
+    let pts: Vec<Point> = (0..2000)
+        .map(|i| {
+            let f = (i % 100) as f64;
+            Point { x: f, y: f, z: f, gps_time: Some(1000.0 + i as f64), ..Default::default() }
+        })
+        .collect();
+    let n = pts.len();
+
+    let mut buf = Cursor::new(Vec::<u8>::new());
+    {
+        let mut w = CopcWriter::new(&mut buf, header_with_extra_evlr(), -1, -1).unwrap();
+        w.write(pts, n as i32).unwrap();
+    }
+
+    buf.set_position(0);
+    let mut r = CopcReader::new(buf).expect("reader must open a COPC written from an EVLR-bearing header");
+    assert!(r.num_entries() > 0, "COPC hierarchy must be present/readable");
+    let read = r
+        .points(LodSelection::All, BoundsSelection::All)
+        .unwrap()
+        .count();
+    assert_eq!(read, n, "all points must round-trip");
+}

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,64 @@
+//! Regression test for the build against current `las`/`laz`, plus a basic
+//! write -> read round-trip through copc-rs's own writer and reader.
+//!
+//! With copc-rs's stale `laz = "0.9"` pin, a fresh dependency resolution selects
+//! `las 0.9.11` (which uses `laz 0.12`) while copc-rs pulls `laz 0.9`, so
+//! `header.laz_vlr()` is a different `LazVlr` type and the crate does not compile.
+//! This test therefore fails to *build* before the fix and passes after it.
+
+use std::io::Cursor;
+
+use copc_rs::{BoundsSelection, CopcReader, CopcWriter, LodSelection};
+use las::point::Format;
+use las::{Builder, Point, Transform, Vector, Vlr};
+
+const WKT: &[u8] = b"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+
+fn header_with_bounds() -> las::Header {
+    let mut b = Builder::from((1u8, 4u8));
+    b.point_format = Format::new(6).unwrap();
+    let t = Transform { scale: 0.01, offset: 0.0 };
+    b.transforms = Vector { x: t, y: t, z: t };
+    // raw round-trip only to stamp non-degenerate bounds (Builder has no bounds field)
+    let mut raw = b.into_header().unwrap().into_raw().unwrap();
+    raw.min_x = 0.0;
+    raw.max_x = 100.0;
+    raw.min_y = 0.0;
+    raw.max_y = 100.0;
+    raw.min_z = 0.0;
+    raw.max_z = 100.0;
+    // VLRs are not part of raw::Header, so add the mandatory WKT CRS VLR afterwards.
+    let mut b2 = Builder::new(raw).unwrap();
+    b2.vlrs.push(Vlr {
+        user_id: "LASF_Projection".into(),
+        record_id: 2112,
+        description: String::new(),
+        data: WKT.to_vec(),
+    });
+    b2.into_header().unwrap()
+}
+
+#[test]
+fn writes_and_reads_back_all_points() {
+    let pts: Vec<Point> = (0..500)
+        .map(|i| {
+            let f = (i % 100) as f64;
+            Point { x: f, y: f, z: f, gps_time: Some(1000.0 + i as f64), ..Default::default() }
+        })
+        .collect();
+    let n = pts.len();
+
+    let mut buf = Cursor::new(Vec::<u8>::new());
+    {
+        let mut w = CopcWriter::new(&mut buf, header_with_bounds(), -1, -1).unwrap();
+        w.write(pts, n as i32).unwrap();
+    }
+
+    buf.set_position(0);
+    let mut r = CopcReader::new(buf).unwrap();
+    let read = r
+        .points(LodSelection::All, BoundsSelection::All)
+        .unwrap()
+        .count();
+    assert_eq!(read, n, "every written point must round-trip");
+}


### PR DESCRIPTION
When the input header already carried an EVLR, `close()` updated `start_of_first_evlr` and `number_of_evlrs` on a **copy**:

```rust
if let Some(mut e) = raw_header.evlr {   // las::raw::header::Evlr is Copy -> local copy
    e.start_of_first_evlr = start_of_first_evlr;
    e.number_of_evlrs += 1;              // discarded
}
```

The mutations were dropped, so the header was written with the input's **stale** EVLR offset/count. A reader then seeks to the wrong offset and reads too few EVLRs, so the COPC EPT-hierarchy EVLR is never found.

Binding by mutable reference (`if let Some(e) = &mut raw_header.evlr`) makes the update persist. Adds `tests/evlr_roundtrip.rs`: with a pre-existing input EVLR, `CopcReader::new` fails with `UnexpectedEof` before the fix and round-trips after. (Inputs with no EVLR — the common case — are unaffected; that path already builds a fresh `Evlr` correctly.)

---
Stacked on #12 (needed to build against current `las`). Will rebase to a single commit once #12 merges.
